### PR TITLE
Document domain models for booking context

### DIFF
--- a/input/fsh/operations/operation-getoffering.md
+++ b/input/fsh/operations/operation-getoffering.md
@@ -1,0 +1,124 @@
+# `$getOffersContext` — Booking Content Context (FHIR)
+
+## Purpose
+`$getOffersContext` is a **read-oriented** FHIR operation designed to let a frontend **quickly populate booking content** so a patient can choose *what* to book and *with whom/where* — without needing multiple round-trips.
+
+This operation returns a **profiled Bundle** that may include:
+
+- `ActivityDefinitionPortal` (what is being offered)
+- `HealthcareServicePortal` (where / which clinic service offers it)
+- `PractitionerRolePortal` (who can perform it)
+- **Offer** resources (a lightweight “relation + settings” object)
+
+The response is intentionally shaped for **fast content rendering**, not for scheduling.
+
+---
+
+## What this operation is NOT
+`$getOffersContext` does **not** answer:
+- Whether a practitioner is working right now
+- Schedule availability
+- Which time slots are bookable
+
+In other words:
+- **No Schedule**
+- **No Slot**
+- **No bookable times**
+
+Those concerns belong to downstream availability/slot endpoints.
+
+---
+
+## Operation name
+- Operation: **`$getOffersContext`**
+
+---
+
+## Endpoints
+The operation can be exposed at (at least) the following levels:
+
+- System:  
+  `GET /fhir/$getOffersContext`
+
+- ActivityDefinition scope:  
+  `GET /fhir/ActivityDefinition/{id}/$getOffersContext`
+
+- HealthcareService scope:  
+  `GET /fhir/HealthcareService/{id}/$getOffersContext`
+
+- PractitionerRole scope:  
+  `GET /fhir/PractitionerRole/{id}/$getOffersContext`
+
+> The server may return different subsets depending on the endpoint and/or query parameters, but the response is always a Bundle.
+
+---
+
+## Response
+### Resource type
+- **Bundle** (profiled)
+
+### Included resources (depending on inputs)
+The response Bundle MAY include any combination of:
+- `ActivityDefinitionPortal`
+- `HealthcareServicePortal`
+- `PractitionerRolePortal`
+- `OfferPortal` (custom resource/profile)
+
+---
+
+## The `OfferPortal` resource (custom, profiled)
+`OfferPortal` is the compact “join object” used by clients to connect:
+- *what* (`ActivityDefinitionPortal`)
+- *where* (`HealthcareServicePortal`)
+- *who* (`PractitionerRolePortal`)
+
+An `Offer` contains:
+- `healthcareService` — **Reference(HealthcareServicePortal)** (with `display` populated when possible)
+- `practitionerRole` — **Reference(PractitionerRolePortal)** (with `display` populated when possible)
+- `activityDefinition` — **Reference(ActivityDefinitionPortal)** (with `display` populated when possible)
+
+`Offer` may also include **presentation-focused settings** needed for booking content, e.g.:
+- duration (free-text)
+- price (free-text)
+- booking URL / deeplink
+
+> Note: duration and price are intended for booking/marketing presentation. They are not required to be machine-parseable.
+
+---
+
+## Why Bundle (instead of Parameters)
+We use a profiled Bundle so that:
+- Clients can reuse standard FHIR parsing patterns
+- Resources can be included once and referenced from multiple offers
+- The payload remains efficient for “chatty” consumers
+
+---
+
+## Typical client usage
+1. Call `$getOffersContext` for a scope (e.g. an ActivityDefinition).
+2. Parse the Bundle and build in-memory maps:
+   - `ActivityDefinition` by id
+   - `HealthcareService` by id
+   - `PractitionerRole` by id
+   - `Offer` list
+3. Render booking options:
+   - group by clinic (HealthcareService)
+   - show practitioners (PractitionerRole)
+   - show the selected activity (ActivityDefinition)
+   - show offer-specific settings (duration/price/deeplink)
+
+---
+
+## Non-goals / exclusions
+- No scheduling, working hours, or shift logic
+- No real-time availability
+- No Slot calculation
+- No guarantee that all returned practitioners are currently working
+
+---
+
+## Glossary
+- **ActivityDefinition**: what can be booked (e.g., “Examination”)
+- **HealthcareService**: a clinic/service unit offering the activity
+- **PractitionerRole**: a practitioner in a role relevant for booking
+- **Offer**: the relationship + settings that ties the above together

--- a/input/fsh/profiles/StructureDefinition-ActivityDefinitionPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-ActivityDefinitionPortal.fsh
@@ -1,0 +1,35 @@
+Profile: ActivityDefinitionPortal
+Parent: ActivityDefinition
+Id: activity-definition-portal
+Title: "ActivityDefinitionPortal"
+Description: """
+<p><b>ActivityDefinition</b> represents what can be offered and booked as a service.</p>
+
+<p>It answers the question: <i>“What service is the patient booking?”</i></p>
+
+<ul>
+  <li>Defines the <b>type of service</b> (e.g., examination, consultation, treatment).</li>
+  <li>Contains a <b>booking activity code</b> that uniquely identifies the service concept.</li>
+  <li>Provides stable metadata such as title and description for presentation and search.</li>
+</ul>
+
+<p><b>Booking and interoperability principle:</b></p>
+
+<ul>
+  <li>Booking is performed using the <b>activity code</b>, not the resource id.</li>
+  <li>This follows the approach used in IHE Scheduling profiles.</li>
+  <li>The code represents a <b>shared service concept</b> that can be reused across installations and systems.</li>
+</ul>
+
+<p><b>Important:</b> The resource <code>id</code> is a technical identifier local to a FHIR server. It MUST NOT be used as a booking key.</p>
+
+<p>ActivityDefinitionPortal describes the service concept only. It does <b>not</b> define:</p>
+<ul>
+  <li>which locations offer the service</li>
+  <li>which practitioners perform it</li>
+  <li>context-specific price or duration</li>
+  <li>availability, schedules, or bookable time slots</li>
+</ul>
+
+<p>Those context-specific details are provided through <b>Offer</b> and related context resources.</p>
+"""

--- a/input/fsh/profiles/StructureDefinition-BillingOrganizationPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-BillingOrganizationPortal.fsh
@@ -1,0 +1,30 @@
+Profile: BillingOrganizationPortal
+Id: billing-organization-portal
+Title: "BillingOrganizationModel"
+Description: """
+<p><b>BillingOrganization</b> represents the entity that is financially responsible for healthcare services.</p>
+
+<p>It answers the question: <i>“Who owns invoicing, customer accounts, and statutory reporting for a performed service?”</i></p>
+
+<ul>
+  <li>Owns the invoice number series used for billing.</li>
+  <li>Owns the customer accounts (accounts receivable).</li>
+  <li>Is responsible for statutory and reimbursement reporting to external authorities.</li>
+  <li>Receives payment for performed services.</li>
+</ul>
+
+<p>A BillingOrganization is <b>independent of service location</b>:</p>
+
+<ul>
+  <li>A BillingOrganization may offer its services at <b>multiple HealthcareServices</b>.</li>
+  <li>A HealthcareService may be associated with <b>multiple BillingOrganizations</b>.</li>
+</ul>
+
+<p>This supports scenarios where:</p>
+<ul>
+  <li>Multiple practitioners with separate financial responsibility work at the same service location.</li>
+  <li>A single practitioner or billing entity provides services at several locations.</li>
+</ul>
+
+<p><b>Important:</b> BillingOrganization represents financial responsibility only. It does <b>not</b> describe where care is performed.</p>
+"""

--- a/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
@@ -1,0 +1,18 @@
+Profile: HealthcareServicePortal
+Parent: HealthcareService
+Id: healthcare-service-portal
+Title: "HealthcareServicePortal"  
+Description: """
+<p><b>HealthcareServicePortal</b> represents the place and operational context where care is performed.</p>
+
+<p>It answers the question: <i>“Where can the patient receive a service?”</i></p>
+
+<ul>
+  <li>Describes a service location or service unit (e.g., clinic, department, unit).</li>
+  <li>Used to present booking options such as location/service, contact information, and where the service is delivered.</li>
+  <li>Can be shared by multiple practitioners and roles.</li>
+  <li>Does <b>not</b> represent financial ownership, invoicing responsibility, or statutory reporting responsibility.</li>
+</ul>
+
+<p><b>Important:</b> HealthcareService is an operational concept. Financial and invoicing responsibility is modeled separately.</p>
+"""

--- a/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
@@ -1,0 +1,33 @@
+Profile: OfferPortal
+Parent: Parameters
+Id: offer-portal
+Title: "OfferPortal"
+Description: """
+<p><b>OfferPortal</b> represents a bookable offering in a specific context.</p>
+
+<p>It answers the question: <i>“Which service can be booked, by whom, and where — and what are the booking-facing settings in that context?”</i></p>
+
+<ul>
+  <li>Connects an <b>ActivityDefinitionPortal</b> (what) with a <b>HealthcareServicePortal</b> (where) and a <b>PractitionerRolePortal</b> (who).</li>
+  <li>Represents the <b>context-specific</b> configuration for booking content.</li>
+  <li>Is intended as a lightweight object for frontends to render booking options quickly.</li>
+</ul>
+
+<p>An OfferPortal contains references to:</p>
+<ul>
+  <li><b>activityDefinition</b> — Reference(ActivityDefinitionPortal)</li>
+  <li><b>healthcareService</b> — Reference(HealthcareServicePortal)</li>
+  <li><b>practitionerRole</b> — Reference(PractitionerRolePortal)</li>
+</ul>
+
+<p>OfferPortal may include booking-facing settings such as:</p>
+<ul>
+  <li><b>duration</b> — free-text (presentation value)</li>
+  <li><b>price</b> — free-text (presentation value)</li>
+  <li><b>bookingUrl</b> — deeplink for booking</li>
+</ul>
+
+<p><b>Important:</b> OfferPortal does <b>not</b> represent real-time availability. It does not include schedules, working hours, or bookable time slots.</p>
+
+<p>OfferPortal is a context/read model intended to support fast, “chatty” consumption. It is not a replacement for scheduling or billing workflows.</p>
+"""

--- a/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
@@ -1,0 +1,32 @@
+Profile: PractitionerRolePortal
+Id: practitioner-role-portal
+Title: "PractitionerRolePortal  "
+Description: """
+<p><b>PractitionerRolePortal</b> represents a practitioner acting in a specific operational and financial context.</p>
+
+<p>It answers the question: <i>“In which role, at which service location, and under which financial responsibility does this practitioner perform services?”</i></p>
+
+<ul>
+  <li>Links a <b>PractitionerPortal</b> (the individual person).</li>
+  <li>Links a <b>HealthcareServicePortal</b> (where the service is performed).</li>
+  <li>Links a <b>BillingOrganizationPortal</b> (who is financially responsible).</li>
+</ul>
+
+<p>A PractitionerRole defines the <b>context</b> in which work is performed, not the person itself.</p>
+
+<ul>
+  <li>A Practitioner may have <b>multiple PractitionerRolePortals</b>.</li>
+  <li>A Practitioner may work at <b>multiple HealthcareServicePortals</b>.</li>
+  <li>A Practitioner may act under <b>different BillingOrganizationPortals</b> depending on context.</li>
+</ul>
+
+<p>This makes PractitionerRole the central concept for:</p>
+<ul>
+  <li>Booking and offers</li>
+  <li>Pricing and duration rules</li>
+  <li>Financial responsibility</li>
+  <li>Service-specific configuration</li>
+</ul>
+
+<p><b>Important:</b> PractitionerRolePortal is intentionally used to separate the person from the context in which services are delivered and billed.</p>
+"""

--- a/input/fsh/profiles/StructureDefinition-Schedule.fsh
+++ b/input/fsh/profiles/StructureDefinition-Schedule.fsh
@@ -1,0 +1,32 @@
+Profile: SchedulePortal
+Parent: Schedule        
+Id: schedule-portal
+Title: "SchedulePortal"
+Description: """
+<p><b>SchedulePortal</b> represents when a practitioner is planned to work during a given time period.</p>
+
+<p>It answers the question: <i>“Who is working in the coming weeks, and who can potentially be shown as bookable?”</i></p>
+
+<ul>
+  <li>Provides <b>time-based context</b> for practitioners.</li>
+  <li>Is used to filter which offers may proceed to availability checks.</li>
+  <li>Supports planning and staffing views.</li>
+</ul>
+
+<p><b>Relationship to Offer:</b></p>
+<ul>
+  <li><b>Offer</b> defines what can be presented and selected (what/where/who).</li>
+  <li><b>SchedulePortal</b> indicates when a practitioner is planned to work.</li>
+  <li>A practitioner may have an <b>Offer without a SchedulePortal</b>.</li>
+</ul>
+
+<p><b>Important:</b> A practitioner without SchedulePortal may still be included in offers for presentation and marketing purposes, but must be treated as <b>not currently bookable</b>.</p>
+<p><b>SchedulePortal is not availability:</b></p>
+<ul>
+  <li>SchedulePortal does <b>not</b> represent bookable time slots.</li>
+  <li>SchedulePortal does <b>not</b> guarantee that a booking can be made.</li>
+  <li>Actual bookability requires downstream <b>Slot/availability</b> checks.</li>
+</ul>
+
+<p><b>Design principle:</b> Offer determines eligibility. Schedule determines potential availability. Slot determines actual bookability.</p>
+"""


### PR DESCRIPTION
### Purpose
This PR refines and documents the core domain concepts used in the WOF Portal API.

The goal is to ensure that we share a common understanding of:
- what each concept represents in the domain
- how concepts relate to each other
- how naming differs between WOF Connect (vendor-facing) and WOF Portal (canonical)

### Scope
This PR focuses on **definitions and naming only**.
It does **not** introduce new behavior, data flows, or API functionality.

### What to review
Please review in particular:
- The domain descriptions for:
  - BillingOrganization
  - HealthcareService
  - PractitionerRole
  - ActivityDefinition
  - Offer
  - Schedule
- The naming strategy:
  - WOF Connect profiles vs WOF Portal profiles
  - Use of Portal-suffixed profiles for enriched, canonical views
- The separation between:
  - service concept
  - service location
  - financial responsibility
  - practitioner context
  - availability vs bookability

### Why this matters
Clear domain definitions are critical for:
- consistent implementation
- correct use of offers, scheduling, and availability
- onboarding new team members and vendors
- avoiding accidental coupling between eco
