### PR TITLE
getofferings uppdateringar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+CI published at https://build.fhir.org/ig/servicewell/servicewell.fhir.wof-portal/branches/initial-setup-refinement/index.html
+
+
+
 # Introduction 
 TODO: Give a short introduction of your project. Let this section explain the objectives or the motivation behind this project. 
 

--- a/input/fsh/operations/Operation-GetOffersContext.fsh
+++ b/input/fsh/operations/Operation-GetOffersContext.fsh
@@ -8,7 +8,7 @@ Usage: #definition
 * kind = #operation
 * code = #getOffersContext
 * system = true
-* type = true
+* type = false
 * instance = true
 * description = """
 `$getOffersContext` is a **read-oriented** FHIR operation designed to let a frontend **quickly populate booking content** so a patient can choose *what* to book and *with whom/where* — without needing multiple round-trips.  

--- a/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
@@ -8,7 +8,7 @@ Description: """
 It answers the question: _“Which service can be booked, by whom, and where — and what are the booking-facing settings in that context?”_
 
 """
-
+* obeys offer-portal-offline-reason
 // -------------------- SLICE: parameter by name --------------------
 * parameter ^slicing.discriminator[0].type = #value
 * parameter ^slicing.discriminator[0].path = "name"
@@ -31,7 +31,7 @@ It answers the question: _“Which service can be booked, by whom, and where —
     price 0..1 and
     bookingUrl 0..1 and
     isOnline 1..1 and
-    offlineReason 1..1
+    offlineReason 0..1
 
 // ---- activityDefinition ----
 * parameter[offering].part[activityDefinition].name = "activityDefinition" (exactly)
@@ -64,3 +64,9 @@ It answers the question: _“Which service can be booked, by whom, and where —
 //------ offline status reason -----
 * parameter[offering].part[offlineReason].name = "offlineReason" (exactly)
 * parameter[offering].part[offlineReason].value[x] only string
+
+// -------------------- INVARIANTS --------------------
+Invariant: offer-portal-offline-reason
+Description: "If isOnline is false, offlineReason must have a value."
+Severity: #error
+Expression: "parameter.where(name='offering').all(part.where(name='isOnline').valueBoolean = false implies (part.where(name='offlineReason').exists() and part.where(name='offlineReason').value.exists()))"

--- a/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-OfferPortal.fsh
@@ -29,7 +29,9 @@ It answers the question: _“Which service can be booked, by whom, and where —
     practitionerRole 1..1 and
     duration 0..1 and
     price 0..1 and
-    bookingUrl 0..1
+    bookingUrl 0..1 and
+    isOnline 1..1 and
+    offlineReason 1..1
 
 // ---- activityDefinition ----
 * parameter[offering].part[activityDefinition].name = "activityDefinition" (exactly)
@@ -54,3 +56,11 @@ It answers the question: _“Which service can be booked, by whom, and where —
 // ---- bookingUrl ----
 * parameter[offering].part[bookingUrl].name = "bookingUrl" (exactly)
 * parameter[offering].part[bookingUrl].value[x] only url
+
+//------ endpoint status -----
+* parameter[offering].part[isOnline].name = "isOnline" (exactly)
+* parameter[offering].part[isOnline].value[x] only boolean
+
+//------ offline status reason -----
+* parameter[offering].part[offlineReason].name = "offlineReason" (exactly)
+* parameter[offering].part[offlineReason].value[x] only string

--- a/input/resources/GetOfferingsResponse-no-include.json
+++ b/input/resources/GetOfferingsResponse-no-include.json
@@ -1,0 +1,163 @@
+{
+  "resourceType": "Bundle",
+  "id": "119d41e8-a9f6-41f1-8841-0c4a50c136ff",
+  "meta":{
+    "profile": [
+      "https://canonical.fhir.link/servicewell/wof-portal/StructureDefinition/offer-portal"
+    ]
+  },
+  "type": "searchset",
+  "total": 8,
+  "entry": [
+    {
+      "fullUrl": "[[baseurl]]/portal/fhir/Parameters/6673fcbc-b928-48db-9ccc-1a1f84883c86",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "6673fcbc-b928-48db-9ccc-1a1f84883c86",
+        "parameter": [
+          {
+            "name": "offering",
+            "part": [
+              {
+                "name": "activityDefinition",
+                "valueReference": {
+                  "reference": "ActivityDefinition/50490e09-f308-4368-a64d-5df12661c48c",
+                  "display": "Akut tandvård"
+                }
+              },
+              {
+                "name": "healthcareService",
+                "valueReference": {
+                  "reference": "HealthcareService/b4108577-c8d2-4198-948e-c23e7937f752",
+                  "display": "OpusSatra"
+                }
+              },
+              {
+                "name": "practitionerRole",
+                "valueReference": {
+                  "reference": "PractitionerRole/ea716976-8fbe-4026-8d26-60d8ec3f7ef4",
+                  "display": "Tandhygienist Samer Salman"
+                }
+              },
+              {
+                "name": "duration",
+                "valueString": "20"
+              },
+              {
+                "name": "price",
+                "valueString": "2000"
+              },
+              {
+                "name": "isOnline",
+                "valueBoolean": true
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "[[baseurl]]/portal/fhir/Parameters/cca56ca1-0c89-492a-9caf-793936361609",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "cca56ca1-0c89-492a-9caf-793936361609",
+        "parameter": [
+          {
+            "name": "offering",
+            "part": [
+              {
+                "name": "activityDefinition",
+                "valueReference": {
+                  "reference": "ActivityDefinition/b1ac81a6-6142-4ef8-ae1f-6f3fea7ed37f",
+                  "display": "Tandhygienist"
+                }
+              },
+              {
+                "name": "healthcareService",
+                "valueReference": {
+                  "reference": "HealthcareService/b4108577-c8d2-4198-948e-c23e7937f752",
+                  "display": "OpusSatra"
+                }
+              },
+              {
+                "name": "practitionerRole",
+                "valueReference": {
+                  "reference": "PractitionerRole/ea716976-8fbe-4026-8d26-60d8ec3f7ef4",
+                  "display": "Tandhygienist Samer Salman"
+                }
+              },
+              {
+                "name": "duration",
+                "valueString": "40"
+              },
+              {
+                "name": "price",
+                "valueString": "1900"
+              },
+              {
+                "name": "isOnline",
+                "valueBoolean": true
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "[[baseurl]]/portal/fhir/Parameters/9184a5d4-fb69-4b0b-8eee-608e6359a6d9",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "9184a5d4-fb69-4b0b-8eee-608e6359a6d9",
+        "parameter": [
+          {
+            "name": "offering",
+            "part": [
+              {
+                "name": "activityDefinition",
+                "valueReference": {
+                  "reference": "ActivityDefinition/3c40a78c-e0b5-4000-9feb-96fc2fe9ba8a",
+                  "display": "Undersökning"
+                }
+              },
+              {
+                "name": "healthcareService",
+                "valueReference": {
+                  "reference": "HealthcareService/b4108577-c8d2-4198-948e-c23e7937f752",
+                  "display": "OpusSatra"
+                }
+              },
+              {
+                "name": "practitionerRole",
+                "valueReference": {
+                  "reference": "PractitionerRole/ea716976-8fbe-4026-8d26-60d8ec3f7ef4",
+                  "display": "Tandhygienist Samer Salman"
+                }
+              },
+              {
+                "name": "duration",
+                "valueString": "30"
+              },
+              {
+                "name": "price",
+                "valueString": "500"
+              },
+              {
+                "name": "isOnline",
+                "valueBoolean": true
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    }
+  ]
+}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -159,7 +159,14 @@ menu:
 #     better option (see below).
 # The following are simple examples to demonstrate what this might
 # look like:
-#
+
+resources:
+  Bundle/119d41e8-a9f6-41f1-8841-0c4a50c136ff:
+    name: GetOfferingsResponse — only references
+    description: Example of the GetOfferingsResponseBundle without entries for referenced resources
+    exampleCanonical: https://canonical.fhir.link/servicewell/wof-portal/StructureDefinition/offer-portal
+
+
 # resources:
 #   Patient/my-example-patient:
 #     name: My Example Patient


### PR DESCRIPTION
This pull request introduces enhancements to the OfferPortal FHIR profile and related documentation, focusing on supporting online/offline status for offerings, updating the example response bundle, and improving project visibility. The most significant changes are grouped below.

**OfferPortal Profile Enhancements:**

**Added two new fields**, 
- `isOnline` (boolean, required) 
- `offlineReason` (string), 
to the `offering` parameter in the OfferPortal profile to indicate the online status and provide a reason when offline. [[1]](diffhunk://#diff-2ed5983ca4ee5575e37cc5ea65da1c7a0869e0c2d5cafe933a387c3691ee8822L32-R34) [[2]](diffhunk://#diff-2ed5983ca4ee5575e37cc5ea65da1c7a0869e0c2d5cafe933a387c3691ee8822R59-R66)

**FHIR Operation and Example Data Updates:**

* Updated the `Operation-GetOffersContext`  `type = false`, clarifying that the operation is not type-specific.
* Added a new example response bundle `GetOfferingsResponse-no-include.json` 
* Registered the new example bundle in `sushi-config.yaml` for documentation and validation purposes.

**Documentation Improvements:**

* Added a link to the continuous integration (CI) published build in the `README.md` for easier access to the latest documentation.