### PR TITLE
Add user profiles

### DIFF
--- a/input/fsh/extensions/StructureDefinition-WofPortalHealthcareServiceExtensions.fsh
+++ b/input/fsh/extensions/StructureDefinition-WofPortalHealthcareServiceExtensions.fsh
@@ -1,0 +1,108 @@
+Extension: UrlPlaceholder
+Id: ext-url-placeholder
+Title: "URL Placeholder"
+Description: "Placeholder URL for clinic booking links."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicInfoDirections
+Id: ext-clinic-info-directions
+Title: "Clinic Directions"
+Description: "Directions for how to reach the clinic."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicInfoParking
+Id: ext-clinic-info-parking
+Title: "Clinic Parking"
+Description: "Parking information for the clinic."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicInfoAbout
+Id: ext-clinic-info-about
+Title: "Clinic About"
+Description: "Description about the clinic."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicInfoSpokenLanguages
+Id: ext-clinic-info-spoken-languages
+Title: "Clinic Spoken Languages"
+Description: "Languages spoken at the clinic."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicInfoBookingSummaryInformationText
+Id: ext-clinic-info-booking-summary-information-text
+Title: "Booking Summary Information"
+Description: "Information text shown during booking summary."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only string
+
+
+
+Extension: ClinicPicture
+Id: ext-clinic-picture
+Title: "Clinic Picture"
+Description: "Reference to a contained Binary resource representing a clinic image."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* value[x] only Reference(Binary)
+
+
+
+Extension: HealthcareServiceAttachments
+Id: ext-healthcare-service-attachments
+Title: "HealthcareService Attachments"
+Description: "Attachment container extension for booking rules."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "HealthcareService"
+
+* extension contains
+    healthcareServiceBookingRules 0..1 and
+    careProviderBookingRules 0..1
+
+* extension[healthcareServiceBookingRules].value[x] only Attachment
+* extension[careProviderBookingRules].value[x] only Attachment
+
+* value[x] 0..0

--- a/input/fsh/extensions/StrucutreDefinition-WofPortalSortKey.fsh
+++ b/input/fsh/extensions/StrucutreDefinition-WofPortalSortKey.fsh
@@ -1,0 +1,14 @@
+Extension: SortKey
+Id: ext-sort-key
+Title: "Sort Key"
+Description: "Sort order key for Location."
+
+* ^status = #active
+* ^context[0].type = #fhirpath
+* ^context[0].expression = "Location"
+* ^context[1].type = #fhirpath
+* ^context[1].expression = "ActivityDefinition"
+
+* value[x] only integer
+
+

--- a/input/fsh/profiles/StructureDefinition-ActivityDefinitionPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-ActivityDefinitionPortal.fsh
@@ -7,3 +7,37 @@ Description: """
 
 It answers the question: _“What service is the patient booking?”_
 """
+* ^status = #active
+
+* id 1..1
+
+* meta.profile 0..*
+
+* date 1..1
+* status 1..1
+
+* name 1..1
+* title 1..1
+* subtitle 0..1
+* description 1..1
+
+* code 1..1
+* code.coding 0..1
+* code.coding.code 0..1
+* code.coding.system 0..1
+
+* kind 0..1
+
+* extension contains SortKey named sortKey 0..1
+* extension contains Campaigns named campaigns 0..1
+
+Extension: Campaigns
+Id: ext-campaigns
+Title: "Campaigns"
+Description: "Campaign identifiers encoded as JSON."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "ActivityDefinition"
+
+* value[x] only Attachment

--- a/input/fsh/profiles/StructureDefinition-BillingOrganizationPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-BillingOrganizationPortal.fsh
@@ -8,3 +8,16 @@ Description: "BillingOrganization represents the entity that is financially resp
 
 It answers the question: _“Who owns invoicing, customer accounts, and statutory reporting for a performed service?”_
 """
+
+//* ^status = #active
+//* id 0..1
+//* meta 0..1
+//* meta.profile 0..*
+//* name 0..1
+//* active 0..1
+//* identifier 0..*
+//* identifier.system 0..1
+//* identifier.value 0..1
+//* telecom 0..1
+//* telecom.system 0..1
+//* telecom.value 0..1

--- a/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
@@ -8,3 +8,38 @@ Description: """
 It answers the question: _“Where can the patient receive a service?”_
 
 """
+
+* ^status = #active
+
+* id 1..1 MS
+* meta.profile 0..*
+
+* providedBy 1..1
+
+* name 1..1
+* active 1..1
+
+* telecom 0..*
+* telecom.system 0..1
+* telecom.use 0..1
+* telecom.value 0..1
+* telecom.rank 0..1
+
+* location 1..*
+
+* endpoint 1..1
+* endpoint.reference 0..1
+* endpoint.display 0..1
+
+* availableTime 0..*
+
+* contained 0..*
+
+* extension contains UrlPlaceholder named urlPlaceholder 0..1
+* extension contains ClinicInfoDirections named directions 0..1
+* extension contains ClinicInfoParking named parking 0..1
+* extension contains ClinicInfoAbout named about 0..1
+* extension contains ClinicInfoSpokenLanguages named spokenLanguages 0..1
+* extension contains ClinicInfoBookingSummaryInformationText named bookingSummaryInformationText 0..1
+* extension contains ClinicPicture named clinicPicture 0..1
+* extension contains HealthcareServiceAttachments named attachments 0..1

--- a/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
@@ -8,3 +8,54 @@ Description: """
 It answers the question: _“In which role, at which service location, and under which financial responsibility does this practitioner perform services?”_
 
 """
+
+* ^status = #active
+
+* id 1..1
+
+* meta.profile 0..*
+
+* active 1..1
+
+* code 1..*
+* specialty 1..*
+
+* practitioner 1..1
+* practitioner.reference 0..1
+* practitioner.display 1..1
+
+* healthcareService 1..*
+* healthcareService.reference 0..1
+* healthcareService.display 0..1
+
+* organization 1..1
+* organization.reference 0..1
+* organization.display 1..1
+* organization.type 0..1
+
+* extension contains PractitionerRoleDescription named description 0..1
+* extension contains BinaryReference named binaryReference 0..1
+
+* contained 0..*
+
+Extension: PractitionerRoleDescription
+Id: ext-practitionerrole-description
+Title: "PractitionerRole Description"
+Description: "Description of the practitioner role."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "PractitionerRole"
+
+* value[x] only string
+
+Extension: BinaryReference
+Id: ext-binary-reference
+Title: "Binary Reference"
+Description: "Reference to a contained Binary resource."
+
+* ^status = #active
+* ^context.type = #element
+* ^context.expression = "PractitionerRole"
+
+* value[x] only Reference(Binary)

--- a/input/fsh/profiles/StrucutreDefinition-LocationArea.fsh
+++ b/input/fsh/profiles/StrucutreDefinition-LocationArea.fsh
@@ -1,0 +1,23 @@
+Profile: LocationArea
+Parent: Location
+Id: LocationArea
+Title: "Location Area"
+Description: "Location profile exposed by WOF Portal Public API."
+
+* ^url = "http://portal.wof.purified.link/fhir/StructureDefinition/LocationArea"
+* ^status = #active
+
+* meta.profile 0..*
+
+* id 1..1
+
+* status 1..1
+
+* name 1..1
+
+* physicalType 1..1
+* physicalType.coding 0..1
+* physicalType.coding.code 0..1
+
+* extension contains SortKey named sortKey 0..1
+


### PR DESCRIPTION
Adds element constraints, custom extensions, and a new profile to the WOF Portal FHIR resource profiles. This brings the previously skeleton-only profiles up to a level where they reflect the actual data shape exposed by the WOF Portal Public API.

New profiles
LocationArea — Location profile with required status, name, physicalType, and optional SortKey extension.

### New extensions (12 total)
#### Grouped by target resource:

HealthcareService (8): UrlPlaceholder, ClinicInfoDirections, ClinicInfoParking, ClinicInfoAbout, ClinicInfoSpokenLanguages, ClinicInfoBookingSummaryInformationText, ClinicPicture, HealthcareServiceAttachments
PractitionerRole (2): PractitionerRoleDescription, BinaryReference
ActivityDefinition (1): Campaigns
Location + ActivityDefinition (1): SortKey

### Updated profiles
ActivityDefinitionPortal — required elements + SortKey & Campaigns extensions
HealthcareServicePortal — required elements + 8 HealthcareService extensions
PractitionerRolePortal — required elements + PractitionerRoleDescription & BinaryReference extensions
BillingOrganizationPortal — commented-out constraints (prepared for future activation)
Stats: 7 files changed, +279 −1