### PR TITLE
Link/appointment device

### DIFF
--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -26,6 +26,25 @@ Appointment representation of a booked visit.
 * identifier[sourceSystemIdentifier].value 1..1 MS
 * identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
 
+
+* supportingInformation ^slicing.discriminator.type = #value
+* supportingInformation ^slicing.discriminator.path = "$this"
+* supportingInformation ^slicing.rules = #open
+* supportingInformation ^slicing.description = ""
+* supportingInformation ^slicing.ordered = false
+
+* supportingInformation contains deviceId 0..1 MS
+* supportingInformation[deviceId] ^short = "Identifies the chair or treatment unit required for the booking when a specific device must be used."
+* supportingInformation[deviceId] ^definition = "Used when the appointment must be booked against a specific chair or treatment unit. If the practitioner is tied to a specific chair at the time of booking, this information shall be included here. The identifier.value is a logical reference to the unique identifier of that chair or treatment unit."
+
+* supportingInformation[deviceId].identifier.value 1..1 MS
+* supportingInformation[deviceId].identifier.value ^short = "Logical reference to the unique identifier of the required chair or treatment unit."
+* supportingInformation[deviceId].identifier.value ^definition = "The logical reference to the unique identifier of the chair or treatment unit that must be used for the appointment booking."
+* supportingInformation[deviceId].identifier.use 0..0
+* supportingInformation[deviceId].reference 0..0
+* supportingInformation[deviceId].display 0..0
+
+
 * participant 3..3
 
 * participant ^slicing.discriminator.type = #value
@@ -89,7 +108,6 @@ Appointment representation of a booked visit.
 * reasonReference 0..0
 * priority 0..0
 * description 0..0
-* supportingInformation 0..0
 * minutesDuration 0..0
 * slot 0..0
 * created 0..0

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -27,7 +27,7 @@ Appointment representation of an available appointment.
 * identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
 * identifier[slot-id].system = "http://canonical.fhir.link/servicewell/wof-connect/identifiercodesystem/slot-id"
 * identifier[slot-id].value  1..1 MS
-* identifier[slot-id].type.text = "Identifier-based reference to the Slot resource that represents this available appointment in the source system."
+* identifier[slot-id].type.text = "id for the available slot"
 
 
 * supportingInformation ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -27,7 +27,26 @@ Appointment representation of an available appointment.
 * identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
 * identifier[slot-id].system = "http://canonical.fhir.link/servicewell/wof-connect/identifiercodesystem/slot-id"
 * identifier[slot-id].value  1..1 MS
-* identifier[slot-id].type.text = "id for the available slot"
+* identifier[slot-id].type.text = "Identifier-based reference to the Slot resource that represents this available appointment in the source system."
+
+
+* supportingInformation ^slicing.discriminator.type = #value
+* supportingInformation ^slicing.discriminator.path = "$this"
+* supportingInformation ^slicing.rules = #open
+* supportingInformation ^slicing.description = ""
+* supportingInformation ^slicing.ordered = false
+
+* supportingInformation contains deviceId 0..1 MS
+* supportingInformation[deviceId] ^short = "Identifies the chair or treatment unit required for the booking when a specific device must be used."
+* supportingInformation[deviceId] ^definition = "Used when the appointment must be booked against a specific chair or treatment unit. If the practitioner is tied to a specific chair at the time of booking, this information shall be included here. The identifier.value is a logical reference to the unique identifier of that chair or treatment unit."
+
+* supportingInformation[deviceId].identifier.value 1..1 MS
+* supportingInformation[deviceId].identifier.value ^short = "Logical reference to the unique identifier of the required chair or treatment unit."
+* supportingInformation[deviceId].identifier.value ^definition = "The logical reference to the unique identifier of the chair or treatment unit that must be used for the appointment booking."
+* supportingInformation[deviceId].identifier.use 0..0
+* supportingInformation[deviceId].reference 0..0
+* supportingInformation[deviceId].display 0..0
+
 
 * status = #proposed
 * serviceType 1..*

--- a/input/fsh/profiles/wofbase/StructureDefinition-WofBaseActivityDefinition.fsh
+++ b/input/fsh/profiles/wofbase/StructureDefinition-WofBaseActivityDefinition.fsh
@@ -77,7 +77,6 @@ Description: """Base profile of wof ActivityDefinition"""
 * implicitRules 0..0
 * language 0..0
 * identifier 0..0
-* subtitle 0..0
 * experimental 0..0
 * subject[x] 0..0
 * useContext 0..0

--- a/input/fsh/profiles/wofbase/StructureDefinition-WofBaseAppointment.fsh
+++ b/input/fsh/profiles/wofbase/StructureDefinition-WofBaseAppointment.fsh
@@ -42,7 +42,6 @@ Description: "Base profile of wof Appointment. Inherits IHE Scheduling Appointme
 * reasonReference 0..0
 * priority 0..0
 * description 0..0
-* supportingInformation 0..0
 * minutesDuration 0..0
 * slot 0..0
 * created 0..0


### PR DESCRIPTION
This pull request enhances the structure of the `PortalAvailableAppointment` profile by adding support for specifying a required device (such as a chair or treatment unit) for an appointment. The most important changes are grouped below:

**Support for device-specific appointments:**

* Added slicing to the `supportingInformation` element to allow for additional information, specifically a `deviceId`, which identifies the chair or treatment unit required for the booking.
* Defined the `supportingInformation[deviceId]` slice, including its cardinality, description, and definition, to clarify its use and ensure proper documentation.
* Specified required fields for `supportingInformation[deviceId].identifier.value`, making it mandatory and providing short and detailed definitions for clarity.
* Set constraints to disallow the use of the `use`, `reference`, and `display` subfields within `supportingInformation[deviceId]`, ensuring only the logical identifier is used.