### PR TITLE
förbättrat slicing genom att läga till type.code

### DIFF
--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -16,7 +16,7 @@ Appointment representation of a booked visit.
 * identifier 1..* MS
 * identifier.type insert Obligation($wof-portal-client-actor, #SHOULD:ignore)
 * identifier ^slicing.discriminator[0].type = #value
-* identifier ^slicing.discriminator[0].path = "type.text"
+* identifier ^slicing.discriminator[0].path = "type.coding.code"
 * identifier ^slicing.rules = #open
 * identifier contains sourceSystemIdentifier 1..1 MS
 * identifier[sourceSystemIdentifier].type.text = "source systems appointment concept"
@@ -25,6 +25,8 @@ Appointment representation of a booked visit.
 * identifier[sourceSystemIdentifier].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
 * identifier[sourceSystemIdentifier].value 1..1 MS
 * identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
+* identifier[sourceSystemIdentifier].type.coding.code = #sourcesystem-identifier
+* identifier[sourceSystemIdentifier].type.coding.code MS
 
 * participant 3..3
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -13,10 +13,9 @@ Appointment representation of an available appointment.
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAvailableAppointment so clients can safely process it as the WOF Portal service concept profile."
 
 
-* identifier 1..* MS
 * identifier.type insert Obligation($wof-portal-client-actor, #SHOULD:ignore)
 * identifier ^slicing.discriminator[0].type = #value
-* identifier ^slicing.discriminator[0].path = "type.text"
+* identifier ^slicing.discriminator[0].path = "type.coding.code"
 * identifier ^slicing.rules = #open
 * identifier contains sourceSystemIdentifier 1..1 and slot-id 1..1 MS
 * identifier[sourceSystemIdentifier].type.text = "source systems appointment concept"
@@ -25,9 +24,13 @@ Appointment representation of an available appointment.
 * identifier[sourceSystemIdentifier].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
 * identifier[sourceSystemIdentifier].value 1..1 MS
 * identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
+* identifier[sourceSystemIdentifier].type.coding.code = #sourcesystem-identifier
+* identifier[sourceSystemIdentifier].type.coding.code MS
 * identifier[slot-id].system = "http://canonical.fhir.link/servicewell/wof-connect/identifiercodesystem/slot-id"
 * identifier[slot-id].value  1..1 MS
-* identifier[slot-id].type.text = "id for the available slot"
+* identifier[slot-id].type.coding.code = #slot-id
+* identifier[slot-id].type.coding.code MS
+* identifier[slot-id].type.text = "Identifier-based reference to the Slot resource that represents this available appointment in the source system."
 
 * status = #proposed
 * serviceType 1..*
@@ -44,12 +47,12 @@ Appointment representation of an available appointment.
 * requestedPeriod.end 1..1
 
 * participant ^slicing.discriminator.type = #type
-* participant ^slicing.discriminator.path = "actor"
+* participant ^slicing.discriminator.path = "actor.resolve()"
 * participant ^slicing.rules = #open
 * participant ^slicing.description = ""
 * participant ^slicing.ordered = false
 
-* participant contains healthcareService 0..1 and practitionerRole 0..1
+* participant contains healthcareService 0..1 MS and practitionerRole 0..1 MS
 * participant[healthcareService].actor only Reference(HealthcareServicePortal)
 * participant[practitionerRole].actor only Reference(PractitionerRolePortal)
 
@@ -72,7 +75,6 @@ Appointment representation of an available appointment.
 * reasonReference 0..0
 * priority 0..0
 * description 0..0
-* supportingInformation 0..0
 * minutesDuration 0..0
 * slot 0..0
 * created 0..0


### PR DESCRIPTION
This pull request updates the FHIR profile definition for `PortalAvailableAppointment` to enhance identifier slicing, clarify participant references, and add more precise coding for identifiers. The changes improve the structure and semantic clarity of the profile, making it easier for clients and systems to process and validate appointment data accurately.

**Identifier enhancements:**

* Changed the identifier slicing discriminator path from `type.text` to `type.coding.code` for more precise slicing and added explicit coding for both `sourceSystemIdentifier` and `slot-id` identifiers, marking them as must-support. [[1]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162L16-R18) [[2]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162R27-R33)

**Participant reference improvements:**

* Updated the participant slicing discriminator path to use `actor.resolve()` for more accurate reference resolution and marked both `healthcareService` and `practitionerRole` participants as must-support.

**Other adjustments:**

* Removed the `supportingInformation` element from the profile, further constraining the appointment resource.