### PR TITLE
Link/appointmentidentifier

### DIFF
--- a/input/fsh/invariants/invariants.fsh
+++ b/input/fsh/invariants/invariants.fsh
@@ -2,11 +2,11 @@
 Invariant: pba-idsys
 Description: "identifier[sourceAppointmentId].system SHALL match the canonical endpoint identifier system URI pattern for appointment context."
 Severity: #error
-Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/[ \\r\\n\\t\\S]+$')"
+Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')"
 
 
 Invariant: paa-idsys
 Description: "identifier[sourceAppointmentId].system SHALL match the canonical endpoint identifier system URI pattern for appointment context."
 Severity: #error
-Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot/[ \\r\\n\\t\\S]+$')"
+Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')"
 

--- a/input/fsh/invariants/invariants.fsh
+++ b/input/fsh/invariants/invariants.fsh
@@ -1,0 +1,12 @@
+
+Invariant: pba-idsys
+Description: "identifier[sourceAppointmentId].system SHALL match the canonical endpoint identifier system URI pattern for appointment context."
+Severity: #error
+Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/[ \\r\\n\\t\\S]+$')"
+
+
+Invariant: paa-idsys
+Description: "identifier[sourceAppointmentId].system SHALL match the canonical endpoint identifier system URI pattern for appointment context."
+Severity: #error
+Expression: "$this.matches('^https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot/[ \\r\\n\\t\\S]+$')"
+

--- a/input/fsh/namingsystems/NamingSystem-WofPortalEndpointIdentifierSystems.fsh
+++ b/input/fsh/namingsystems/NamingSystem-WofPortalEndpointIdentifierSystems.fsh
@@ -52,6 +52,21 @@ Pattern: `https://canonical.fhir.link/servicewell/wof-portal/identifier-system/e
 * uniqueId[0].value = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment"
 
 
+Instance: EndpointIdentifierSystemForSlotId
+InstanceOf: NamingSystem
+Usage: #definition
+* name = "EndpointIdentifierSystemForSlotId"
+* status = #active
+* kind = #root
+* date = "2026-04-29"
+* description = """Root identifier namespace for Slot source-system primary keys per endpoint.  
+Pattern: `https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/{endpointId}`"""
+* uniqueId[0].type = #uri
+* uniqueId[0].preferred = true
+* uniqueId[0].value = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id"
+
+
+
 Instance: EndpointIdentifierSystemForPatient
 InstanceOf: NamingSystem
 Usage: #definition

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -12,18 +12,27 @@ Appointment representation of a booked visit.
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PortalAppointment instance."
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAppointment so clients can safely process it as the WOF Portal service concept profile."
 
-
-* identifier 1..* MS
 * identifier ^short = "Must include at least one identifier that identifies the bookable time slot in the source system. Endpoint specific."
-* identifier.system 1..1 MS
-* identifier.system ^short = "Pattern from namingsystem EndpointIdentifierSystemForAppointment"
-* identifier.system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
-* identifier.value 1..1 MS
-* identifier.value ^short = "The source system's id for the available slot"
-* identifier.system ^example[0].label = "uri"
-* identifier.system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
-* identifier.value ^example[0].label = "value"
-* identifier.value ^example[0].valueString = "apt-2024-00142"
+* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.path = "type.coding.code"
+* identifier ^slicing.rules = #open
+* identifier ^slicing.description = ""
+* identifier ^slicing.ordered = false
+
+
+* identifier contains sourceAppointmentId 1..1 MS
+* identifier[sourceAppointmentId].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
+* identifier[sourceAppointmentId].type.coding.code = #FILL
+* identifier[sourceAppointmentId].system 1..1 MS
+* identifier[sourceAppointmentId].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForAppointment"
+* identifier[sourceAppointmentId].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
+* identifier[sourceAppointmentId].system obeys pba-idsys
+* identifier[sourceAppointmentId].value 1..1 MS
+* identifier[sourceAppointmentId].value ^short = "The source system's id for the available slot"
+* identifier[sourceAppointmentId].system ^example[0].label = "uri"
+* identifier[sourceAppointmentId].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
+* identifier[sourceAppointmentId].value ^example[0].label = "value"
+* identifier[sourceAppointmentId].value ^example[0].valueString = "apt-2024-00142"
 
 
 * supportingInformation ^slicing.discriminator.type = #value
@@ -117,4 +126,3 @@ Appointment representation of a booked visit.
 * extension[consentToMarketing] ^short = "Patient consent to marketing"
 * extension[consentToMarketing] ^definition = "Indicates whether the patient has provided consent to receive marketing-related communication."
 * extension[consentToMarketing] insert Obligation($wof-portal-server-actor, #SHALL:handle)
-

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -14,19 +14,16 @@ Appointment representation of a booked visit.
 
 
 * identifier 1..* MS
-* identifier.type insert Obligation($wof-portal-client-actor, #SHOULD:ignore)
-* identifier ^slicing.discriminator[0].type = #value
-* identifier ^slicing.discriminator[0].path = "type.coding.code"
-* identifier ^slicing.rules = #open
-* identifier contains sourceSystemIdentifier 1..1 MS
-* identifier[sourceSystemIdentifier].type.text = "source systems appointment concept"
-* identifier[sourceSystemIdentifier].system 1..1 MS
-* identifier[sourceSystemIdentifier].system ^short = "Identifier-based reference to the Appointment concept in the source system."
-* identifier[sourceSystemIdentifier].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
-* identifier[sourceSystemIdentifier].value 1..1 MS
-* identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
-* identifier[sourceSystemIdentifier].type.coding.code = #sourcesystem-identifier
-* identifier[sourceSystemIdentifier].type.coding.code MS
+* identifier ^short = "Must include at least one identifier that identifies the bookable time slot in the source system. Endpoint specific."
+* identifier.system 1..1 MS
+* identifier.system ^short = "Pattern from namingsystem EndpointIdentifierSystemForAppointment"
+* identifier.system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
+* identifier.value 1..1 MS
+* identifier.value ^short = "The source system's id for the available slot"
+* identifier.system ^example[0].label = "uri"
+* identifier.system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
+* identifier.value ^example[0].label = "value"
+* identifier.value ^example[0].valueString = "apt-2024-00142"
 
 
 * supportingInformation ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -31,12 +31,12 @@ Appointment representation of a booked visit.
 * identifier[sourceAppointmentId].value 1..1 MS
 * identifier[sourceAppointmentId].value ^short = "The source system's id for the booked appointment"
 * identifier[sourceAppointmentId].system ^example[0].label = "Wof Portal"
-* identifier[sourceAppointmentId].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
+* identifier[sourceAppointmentId].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/550e8400-e29b-41d4-a716-446655440000"
 * identifier[sourceAppointmentId].value ^example[0].label = "Wof Portal"
 * identifier[sourceAppointmentId].value ^example[0].valueString = "apt-2024-00142"
 * identifier[sourceAppointmentId].use 0..0
 
-* identifier[sourceSlot-id] ^short = "Used only when modifying an existing appointment | id for chosen slot when appointment is rebooked"
+* identifier[sourceSlot-id] ^short = "Used only when modifying an existing appointment | id for chosen slot when appointment is rescheduled"
 * identifier[sourceSlot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
 * identifier[sourceSlot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
 * identifier[sourceSlot-id].system obeys paa-idsys

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -12,7 +12,7 @@ Appointment representation of a booked visit.
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PortalAppointment instance."
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAppointment so clients can safely process it as the WOF Portal service concept profile."
 
-* identifier ^short = "Must include at least one identifier that identifies the bookable time slot in the source system. Endpoint specific."
+* identifier ^short = "Must include at least one identifier that identifies the time slot in the source system. Endpoint specific."
 * identifier ^slicing.discriminator.type = #value
 * identifier ^slicing.discriminator.path = "type.coding.code"
 * identifier ^slicing.rules = #open
@@ -21,6 +21,7 @@ Appointment representation of a booked visit.
 
 
 * identifier contains sourceAppointmentId 1..1 MS and sourceSlot-id 0..1 MS
+* identifier[sourceAppointmentId] ^short = "Used to identify the booked appointment in the source system"
 * identifier[sourceAppointmentId].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
 * identifier[sourceAppointmentId].type.coding.code = #FILL
 * identifier[sourceAppointmentId].system 1..1 MS
@@ -28,10 +29,10 @@ Appointment representation of a booked visit.
 * identifier[sourceAppointmentId].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
 * identifier[sourceAppointmentId].system obeys pba-idsys
 * identifier[sourceAppointmentId].value 1..1 MS
-* identifier[sourceAppointmentId].value ^short = "The source system's id for the available slot"
-* identifier[sourceAppointmentId].system ^example[0].label = "General"
+* identifier[sourceAppointmentId].value ^short = "The source system's id for the booked appointment"
+* identifier[sourceAppointmentId].system ^example[0].label = "Wof Portal"
 * identifier[sourceAppointmentId].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
-* identifier[sourceAppointmentId].value ^example[0].label = "General"
+* identifier[sourceAppointmentId].value ^example[0].label = "Wof Portal"
 * identifier[sourceAppointmentId].value ^example[0].valueString = "apt-2024-00142"
 * identifier[sourceAppointmentId].use 0..0
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -20,7 +20,7 @@ Appointment representation of a booked visit.
 * identifier ^slicing.ordered = false
 
 
-* identifier contains sourceAppointmentId 1..1 MS
+* identifier contains sourceAppointmentId 1..1 MS and sourceSlot-id 0..1 MS
 * identifier[sourceAppointmentId].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
 * identifier[sourceAppointmentId].type.coding.code = #FILL
 * identifier[sourceAppointmentId].system 1..1 MS
@@ -29,10 +29,22 @@ Appointment representation of a booked visit.
 * identifier[sourceAppointmentId].system obeys pba-idsys
 * identifier[sourceAppointmentId].value 1..1 MS
 * identifier[sourceAppointmentId].value ^short = "The source system's id for the available slot"
-* identifier[sourceAppointmentId].system ^example[0].label = "uri"
+* identifier[sourceAppointmentId].system ^example[0].label = "General"
 * identifier[sourceAppointmentId].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
-* identifier[sourceAppointmentId].value ^example[0].label = "value"
+* identifier[sourceAppointmentId].value ^example[0].label = "General"
 * identifier[sourceAppointmentId].value ^example[0].valueString = "apt-2024-00142"
+* identifier[sourceAppointmentId].use 0..0
+
+* identifier[sourceSlot-id] ^short = "Used only when modifying an existing appointment | id for chosen slot when appointment is rebooked"
+* identifier[sourceSlot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
+* identifier[sourceSlot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
+* identifier[sourceSlot-id].system obeys paa-idsys
+* identifier[sourceSlot-id].value 1..1 MS
+* identifier[sourceSlot-id].value ^short = "The source system's id for the available slot"
+* identifier[sourceSlot-id].use 0..0
+* identifier[sourceSlot-id].type.coding.code = #PLAC
+* identifier[sourceSlot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
+
 
 
 * supportingInformation ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -21,19 +21,19 @@ Appointment representation of an available appointment.
 * identifier ^slicing.ordered = false
 
 
-* identifier contains slot-id 1..1 MS
-* identifier[slot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
-* identifier[slot-id].type.coding.code = #FILL
-* identifier[slot-id].system obeys paa-idsys
-* identifier[slot-id].system 1..1 MS
-* identifier[slot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
-* identifier[slot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
-* identifier[slot-id].value 1..1 MS
-* identifier[slot-id].value ^short = "The source system's id for the available slot"
-* identifier[slot-id].system ^example[0].label = "uri"
-* identifier[slot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/serviceO-12345"
-* identifier[slot-id].value ^example[0].label = "value"
-* identifier[slot-id].value ^example[0].valueString = "slot-2024-00142"
+* identifier contains sourceSlot-id 1..1 MS
+* identifier[sourceSlot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
+* identifier[sourceSlot-id].type.coding.code = #FILL
+* identifier[sourceSlot-id].system obeys paa-idsys
+* identifier[sourceSlot-id].system 1..1 MS
+* identifier[sourceSlot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
+* identifier[sourceSlot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
+* identifier[sourceSlot-id].value 1..1 MS
+* identifier[sourceSlot-id].value ^short = "The source system's id for the available slot"
+* identifier[sourceSlot-id].system ^example[0].label = "uri"
+* identifier[sourceSlot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/serviceO-12345"
+* identifier[sourceSlot-id].value ^example[0].label = "value"
+* identifier[sourceSlot-id].value ^example[0].valueString = "slot-2024-00142"
 
 
 * supportingInformation ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -13,28 +13,21 @@ Appointment representation of an available appointment.
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAvailableAppointment so clients can safely process it as the WOF Portal service concept profile."
 
 
-* identifier.type insert Obligation($wof-portal-client-actor, #SHOULD:ignore)
-* identifier ^slicing.discriminator[0].type = #value
-* identifier ^slicing.discriminator[0].path = "type.coding.code"
-* identifier ^slicing.rules = #open
-* identifier contains sourceSystemIdentifier 1..1 and slot-id 1..1 MS
-* identifier[sourceSystemIdentifier].type.text = "source systems appointment concept"
-* identifier[sourceSystemIdentifier].system 1..1 MS
-* identifier[sourceSystemIdentifier].system ^short = "Identifier-based reference to the Appointment concept in the source system."
-* identifier[sourceSystemIdentifier].system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
-* identifier[sourceSystemIdentifier].value 1..1 MS
-* identifier[sourceSystemIdentifier].value ^short = "Source systems identifier for the appointment"
-* identifier[sourceSystemIdentifier].type.coding.code = #sourcesystem-identifier
-* identifier[sourceSystemIdentifier].type.coding.code MS
-* identifier[slot-id].system = "http://canonical.fhir.link/servicewell/wof-connect/identifiercodesystem/slot-id"
-* identifier[slot-id].value  1..1 MS
-* identifier[slot-id].type.coding.code = #slot-id
-* identifier[slot-id].type.coding.code MS
-* identifier[slot-id].type.text = "Identifier-based reference to the Slot resource that represents this available appointment in the source system."
+* identifier 1..* MS
+* identifier ^short = "Must include at least one identifier that identifies the bookable time slot in the source system. Endpoint specific."
+* identifier.system 1..1 MS
+* identifier.system ^short = "Pattern from namingsystem EndpointIdentifierSystemForAppointment"
+* identifier.system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
+* identifier.value 1..1 MS
+* identifier.value ^short = "The source system's id for the available slot"
+* identifier.system ^example[0].label = "uri"
+* identifier.system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
+* identifier.value ^example[0].label = "value"
+* identifier.value ^example[0].valueString = "apt-2024-00142"
 
 
 * supportingInformation ^slicing.discriminator.type = #value
-* supportingInformation ^slicing.discriminator.path = "$this"
+* supportingInformation ^slicing.discriminator.path = "$type"
 * supportingInformation ^slicing.rules = #open
 * supportingInformation ^slicing.description = ""
 * supportingInformation ^slicing.ordered = false
@@ -48,6 +41,7 @@ Appointment representation of an available appointment.
 * supportingInformation[deviceId].identifier.value ^definition = "The logical reference to the unique identifier of the chair or treatment unit that must be used for the appointment booking."
 * supportingInformation[deviceId].identifier.use 0..0
 * supportingInformation[deviceId].reference 0..0
+* supportingInformation[deviceId].type = #Device
 * supportingInformation[deviceId].display 0..0
 
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -24,7 +24,7 @@ Appointment representation of an available appointment.
 * identifier contains slot-id 1..1 MS
 * identifier[slot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
 * identifier[slot-id].type.coding.code = #FILL
-* identifier[slot-id].system obeys pba-idsys
+* identifier[slot-id].system obeys paa-idsys
 * identifier[slot-id].system 1..1 MS
 * identifier[slot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
 * identifier[slot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -13,17 +13,27 @@ Appointment representation of an available appointment.
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAvailableAppointment so clients can safely process it as the WOF Portal service concept profile."
 
 
-* identifier 1..* MS
 * identifier ^short = "Must include at least one identifier that identifies the bookable time slot in the source system. Endpoint specific."
-* identifier.system 1..1 MS
-* identifier.system ^short = "Pattern from namingsystem EndpointIdentifierSystemForAppointment"
-* identifier.system ^definition = "See [EndpointIdentifierSystemForAppointment](./NamingSystem-EndpointIdentifierSystemForAppointment.html) for expected identifier.system values."
-* identifier.value 1..1 MS
-* identifier.value ^short = "The source system's id for the available slot"
-* identifier.system ^example[0].label = "uri"
-* identifier.system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment/serviceO-12345"
-* identifier.value ^example[0].label = "value"
-* identifier.value ^example[0].valueString = "apt-2024-00142"
+* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.path = "type.coding.code"
+* identifier ^slicing.rules = #open
+* identifier ^slicing.description = ""
+* identifier ^slicing.ordered = false
+
+
+* identifier contains slot-id 1..1 MS
+* identifier[slot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
+* identifier[slot-id].type.coding.code = #FILL
+* identifier[slot-id].system obeys pba-idsys
+* identifier[slot-id].system 1..1 MS
+* identifier[slot-id].system ^short = "Pattern from namingsystem EndpointIdentifierSystemForSlotId"
+* identifier[slot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
+* identifier[slot-id].value 1..1 MS
+* identifier[slot-id].value ^short = "The source system's id for the available slot"
+* identifier[slot-id].system ^example[0].label = "uri"
+* identifier[slot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/serviceO-12345"
+* identifier[slot-id].value ^example[0].label = "value"
+* identifier[slot-id].value ^example[0].valueString = "slot-2024-00142"
 
 
 * supportingInformation ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -32,7 +32,7 @@ Appointment representation of an available appointment.
 * identifier[sourceSlot-id].value 1..1 MS
 * identifier[sourceSlot-id].value ^short = "The source system's id for the available slot"
 * identifier[sourceSlot-id].system ^example[0].label = "Wof Portal"
-* identifier[sourceSlot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/serviceO-12345"
+* identifier[sourceSlot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/550e8400-e29b-41d4-a716-446655440000"
 * identifier[sourceSlot-id].value ^example[0].label = "Wof Portal"
 * identifier[sourceSlot-id].value ^example[0].valueString = "slot-2024-00142"
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -30,9 +30,9 @@ Appointment representation of an available appointment.
 * identifier[sourceSlot-id].system ^definition = "See [EndpointIdentifierSystemForSlotId](./NamingSystem-EndpointIdentifierSystemForSlotId.html) for expected identifier.system values."
 * identifier[sourceSlot-id].value 1..1 MS
 * identifier[sourceSlot-id].value ^short = "The source system's id for the available slot"
-* identifier[sourceSlot-id].system ^example[0].label = "uri"
+* identifier[sourceSlot-id].system ^example[0].label = "Wof Portal"
 * identifier[sourceSlot-id].system ^example[0].valueUri = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-slot-id/serviceO-12345"
-* identifier[sourceSlot-id].value ^example[0].label = "value"
+* identifier[sourceSlot-id].value ^example[0].label = "Wof Portal"
 * identifier[sourceSlot-id].value ^example[0].valueString = "slot-2024-00142"
 
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -22,6 +22,7 @@ Appointment representation of an available appointment.
 
 
 * identifier contains sourceSlot-id 1..1 MS
+* identifier[sourceSlot-id] ^short = "The bookable time slot in the source system. Endpoint specific."
 * identifier[sourceSlot-id].type.coding.code  insert Obligation($wof-portal-client-actor, #MAY:ignore)
 * identifier[sourceSlot-id].type.coding.code = #FILL
 * identifier[sourceSlot-id].system obeys paa-idsys


### PR DESCRIPTION
* Sliceat appointment.identfifer för clarity
* lagt till beskrivande texter
* lagt till invariant som ser till att system mostvarar pattern i namingsystem

**Identifier system and validation improvements:**

* Added new invariants (`pba-idsys` and `paa-idsys`) to enforce that `identifier[sourceAppointmentId].system` and `identifier[slot-id].system` must match specific canonical URI patterns for appointment and slot contexts, respectively.
* Updated the `PortalAppointment` and `PortalAvailableAppointment` profiles to require identifiers (`sourceAppointmentId` and `slot-id`) that conform to the new invariants, with revised short descriptions, definitions, and examples for clarity. [[1]](diffhunk://#diff-99462998801db28ddb937a360bc0fc41df9a844cf1b5a72b1dd27cc11eb82a60L15-R35) [[2]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162L16-R40)

**Canonical naming system additions:**

* Introduced a new `NamingSystem` instance (`EndpointIdentifierSystemForSlotId`) to define the canonical URI pattern for slot identifiers, supporting the new validation logic.

**Profile structure and documentation updates:**

* Refined slicing rules and discriminator usage for identifier fields in both profiles, improving FHIR conformance and documentation. [[1]](diffhunk://#diff-99462998801db28ddb937a360bc0fc41df9a844cf1b5a72b1dd27cc11eb82a60L15-R35) [[2]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162L16-R40)
* Updated the `supportingInformation[deviceId]` element in the available appointment profile to explicitly set `type = #Device`, clarifying its intended usage.