### PR TITLE
Refine/v1.0.0

### DIFF
--- a/input/fsh/examples/AppointmnetBook.fsh
+++ b/input/fsh/examples/AppointmnetBook.fsh
@@ -1,0 +1,59 @@
+Alias: $csServiceType = http://portal.wof.purified.link/fhir/CodeSystem/csServiceType
+
+Instance: BookAppointmentRequestExample
+InstanceOf: Parameters
+Usage: #example
+Title: "Example request for Appointment/$book"
+Description: "FHIR R4 Parameters example for invoking Appointment/$book with an Appointment payload, patient identifier, and comment."
+
+* parameter[+].name = "appointment-resource"
+* parameter[=].resource = 001-2026-06-15T09-30-00-B9-E3-R1
+
+* parameter[+].name = "patient-resource"
+* parameter[=].resource = 17710325-8809-0000-0000-000000000000
+
+* parameter[+].name = "comment"
+* parameter[=].valueString = "Patienten onskar tandlakarbesok fore kl 10.00."
+
+
+
+Instance: 001-2026-06-15T09-30-00-B9-E3-R1
+InstanceOf: Appointment
+Usage: #inline
+* meta.profile = "https://canonical.fhir.link/servicewell/wof-portal/StructureDefinition/portal-available-appointment"
+* extension.url = "https://canonical.fhir.link/servicewell/wof-portal/StructureDefinition/activity-definition-reference"
+* extension.valueReference = Reference(ActivityDefinition/50490e09-f308-4368-a64d-5df12661c48c) "Akut tandvård"
+* identifier[0].system = "http://canonical.fhir.link/servicewell/wof-connect/identifiercodesystem/slot-id"
+* identifier[=].value = "001-2026-06-15T09-30-00-B9-E3-R1"
+* identifier[+].system = "https://canonical.fhir.link/servicewell/wof-portal/identifier-system/endpoint-identifier-system-for-appointment"
+* identifier[=].value = "e0a17fdc-c86c-42a6-82bb-a26b2402db97"
+* status = #proposed
+* serviceType = $csServiceType#Akut "Akut tandvård"
+* start = "2026-06-15T07:30:00+00:00"
+* end = "2026-06-15T07:50:00+00:00"
+* participant[0].actor = Reference(HealthcareService/7e2b91ad-5b3c-4a84-9c5e-1a6d2f8c4b17)
+* participant[=].status = #accepted
+* participant[+].actor = Reference(PractitionerRole/89a530d3-7363-4a1b-9d86-df8802550319) "Tandläkare Olle Ohlsson"
+* participant[=].status = #accepted
+* participant[+].actor.identifier.system = "urn:oid:1.2.752.129.2.1.3.1"
+* participant[=].actor.identifier.value = "17710325-8809"
+* participant[=].status = #accepted
+
+
+
+Instance: 17710325-8809-0000-0000-000000000000
+InstanceOf: PortalPatient
+Usage: #inline
+Description: "Example of a patient in the WOF Portal system."
+
+* meta.profile = "https://canonical.fhir.link/servicewell/wof-portal/StructureDefinition/portal-patient"
+* identifier[personalNumber].system = "urn:oid:1.2.752.129.2.1.3.1"
+* identifier[personalNumber].value = "17710325-8809"
+* telecom[mobilePhone].system = #phone
+* telecom[mobilePhone].value = "+46701234567"
+* telecom[email].system = #email
+* telecom[email].value = "patient@example.se"
+* name.family = "Testsson"
+* name.given[0] = "Tester"
+* name.text = "Tester Testsson"
+

--- a/input/fsh/examples/responses/BundleOrganizationApiResponce.fsh
+++ b/input/fsh/examples/responses/BundleOrganizationApiResponce.fsh
@@ -10,7 +10,7 @@ Description: "API response returning a searchset Bundle of Organization resource
 * entry.search.mode = #match
 
 Instance: 773cc131-574b-4e86-9abd-552d0d25be27
-InstanceOf: Organization
+InstanceOf: ServiceProviderPortal
 Usage: #inline
 * meta.extension.extension.url = "created"
 * meta.extension.extension.valueDateTime = "2025-06-24T11:39:55.797+02:00"

--- a/input/fsh/extensions/StructureDefinition-BannerImage.fsh
+++ b/input/fsh/extensions/StructureDefinition-BannerImage.fsh
@@ -1,0 +1,8 @@
+Extension: extBannerImage
+Id: extBannerImage
+Title: "ext Banner Image"
+Description: "Extension for Organization Banner Image"
+Context: Organization
+
+* value[x] only Reference(Binary)
+* extension 0..0

--- a/input/fsh/operations/Operation-BookAppointments.fsh
+++ b/input/fsh/operations/Operation-BookAppointments.fsh
@@ -23,10 +23,11 @@ Usage: #definition
 * affectsState = true       // Write operation
 * base = "https://profiles.ihe.net/ITI/Scheduling/OperationDefinition/appointment-book"
 
-* outputProfile = Canonical(PortalFindAppointmentBundle) // IHE ITI Scheduling Bundle Profile
+// wrong profile, currently no profile for the bundle response from this operation. OUT is set to 'bundle'
+//* outputProfile = Canonical(PortalFindAppointmentBundle) // IHE ITI Scheduling Bundle Profile
 
 // in: Appointment request (create/modify/cancel)
-* parameter[+].name = #appointment
+* parameter[+].name = #appointment-resource
 * parameter[=].use = #in
 * parameter[=].min = 1
 * parameter[=].max = "1"
@@ -46,23 +47,21 @@ The Appointment to be created, modified, or cancelled.
   - Appointment.status is 'cancelled'
 """
 // in: appointment reference (alternative to full resource for create/modify/cancel) - IHE ITI
-* parameter[+].name = #appointment-reference
-* parameter[=].use = #in
-* parameter[=].min = 0
-* parameter[=].max = "1"
-* parameter[=].documentation = "A resource id for one of proposed Appointments returned by a prior $find operation (e.g., Resource/1234).  References can be to an absolute URL, but servers only perform this operation on their own appointments."
-* parameter[=].type = #Reference
-* parameter[=].targetProfile = Canonical(PortalAppointment) 
+//* parameter[+].name = #appointment-reference
+//* parameter[=].use = #in
+//* parameter[=].min = 0
+//* parameter[=].max = "1"
+//* parameter[=].documentation = "A resource id for one of proposed Appointments returned by a prior $find operation (e.g., Resource/1234).  References can be to an absolute URL, but servers only perform this operation on their own appointments."
+//* parameter[=].type = #Reference
+//* parameter[=].targetProfile = Canonical(PortalAppointment) 
 
-// in: patient resource- IHE ITI
-* parameter[+].name = #patient-identifier
+* parameter[+].name = #patient-resource
 * parameter[=].use = #in
 * parameter[=].min = 1
-* parameter[=].max = "*"
-* parameter[=].documentation = """The Patient is identified by their personal number.  | SHOULD be an identifier system from a national FHIR Patient profile. """
-* parameter[=].type = #Identifier
-
-
+* parameter[=].max = "1"
+* parameter[=].documentation = "Patient resource for whom the appointment is being booked, modified, or cancelled."
+* parameter[=].type = #Patient
+* parameter[=].targetProfile = Canonical(PortalPatient) 
 
 // in: booking comment - IHE ITI
 * parameter[+].name = #comment

--- a/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-HealthcareServicePortal.fsh
@@ -20,6 +20,8 @@ This profile intentionally constrains base FHIR to define a stable and testable 
 * id ^short = "Stable logical identifier for the healthcare service"
 * id ^definition = "The logical id of this HealthcareServicePortal resource. It identifies the specific care offering location instance within the portal."
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific HealthcareServicePortal instance."
+* meta.versionId 0..1 MS
+* meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
 * meta.profile ^definition = "Identifies that the resource conforms to HealthcareServicePortal so clients can safely process it as the WOF Portal service concept profile."
 
 

--- a/input/fsh/profiles/StructureDefinition-PortalPatient.fsh
+++ b/input/fsh/profiles/StructureDefinition-PortalPatient.fsh
@@ -27,12 +27,18 @@ Description: "Representation of a patient in Wof-portal public API system."
 * telecom ^slicing.discriminator[0].type = #value
 * telecom ^slicing.discriminator[0].path = "system"
 * telecom ^slicing.rules = #open
-* telecom contains mobilePhone 0..1 MS and email 0..1 MS
+* telecom contains mobilePhone 1..1 MS and email 0..1 MS
+* telecom[mobilePhone] ^short = "Patient's mobile phone number, used for sms confirmation"
 * telecom[mobilePhone].system = #phone (exactly)
 * telecom[mobilePhone] obeys portal-mobile-or-empty-use
 * telecom[mobilePhone].value 1..1 MS
 * telecom[email].system = #email (exactly)
 * telecom[email].value 1..1 MS
+
+* name 1..1
+* name.family 1..1 MS
+* name.given 1..1 MS 
+* name.text 1..1 MS
 
 // ---- Explicitly prohibited elements (not used in this profile) ----
 * implicitRules 0..0

--- a/input/fsh/profiles/StructureDefinition-PortalPatient.fsh
+++ b/input/fsh/profiles/StructureDefinition-PortalPatient.fsh
@@ -9,6 +9,9 @@ Description: "Representation of a patient in Wof-portal public API system."
 
 * meta.profile ^definition = "Identifies that the resource conforms to PortalPatient so clients can safely process it as the WOF Portal service concept profile."
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PortalPatient instance."
+* meta.versionId 0..1 MS
+* meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
+
 
 * extension contains PortalConsentToMarketing named consentToMarketing 0..1
 * extension[consentToMarketing] ^short = "Patient consent to marketing"

--- a/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-PractitionerRolePortal.fsh
@@ -22,7 +22,8 @@ It answers the question: _“In which role, at which service location, and under
   * ^definition = "Asserts the profile(s) this resource conforms to."
 
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PractitionerRolePortal instance."
-
+* meta.versionId 0..1 MS
+* meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
 
 * active 1..1
   * ^short = "Whether this practitioner role is active"

--- a/input/fsh/profiles/StructureDefinition-ServiceProviderPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-ServiceProviderPortal.fsh
@@ -20,6 +20,35 @@ It answers the question: _“Which organization owns the configuration, endpoint
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific ServiceProviderPortal instance."
 * meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
 
+* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.path = "system"
+* identifier ^slicing.rules = #open
+* identifier ^slicing.description = ""
+* identifier ^slicing.ordered = false
+
+* identifier contains MobileFormTenant 1..1 MS and NameAsCode 1..1 MS
+
+* identifier[MobileFormTenant].system 1..1 MS
+* identifier[MobileFormTenant].system = "http://ki.purified.link/wof-mobileform/fhir/CodeSystem/MobileFormTenantsCs"
+* identifier[MobileFormTenant].system insert Obligation($wof-portal-server-actor, #SHALL:populate)
+* identifier[MobileFormTenant].value 1..1 MS
+* identifier[NameAsCode].system 1..1 MS
+* identifier[NameAsCode].system = "http://portal.wof.purified.link/fhir/CodeSystem/nameAsCode"
+* identifier[NameAsCode].system insert Obligation($wof-portal-server-actor, #SHALL:populate)
+* identifier[NameAsCode].value 1..1 MS
+
+* identifier[MobileFormTenant].use 0..0
+* identifier[MobileFormTenant].type 0..0
+* identifier[MobileFormTenant].period 0..0
+* identifier[NameAsCode].use 0..0
+* identifier[NameAsCode].type 0..0
+* identifier[NameAsCode].period 0..0
+
+* contained ^short = "Used for carrying banner image"
+
+* extension contains extBannerImage named bannerImageExtension 0..1 MS and OrganizationSettings named organizationSettings 1..1 MS
+
+
 // ---- Explicitly prohibited elements (not used in this profile) ----
 * implicitRules 0..0
 * modifierExtension 0..0

--- a/input/fsh/profiles/StructureDefinition-ServiceProviderPortal.fsh
+++ b/input/fsh/profiles/StructureDefinition-ServiceProviderPortal.fsh
@@ -26,7 +26,7 @@ It answers the question: _“Which organization owns the configuration, endpoint
 * identifier ^slicing.description = ""
 * identifier ^slicing.ordered = false
 
-* identifier contains MobileFormTenant 1..1 MS and NameAsCode 1..1 MS
+* identifier contains MobileFormTenant 0..1 MS and NameAsCode 0..1 MS
 
 * identifier[MobileFormTenant].system 1..1 MS
 * identifier[MobileFormTenant].system = "http://ki.purified.link/wof-mobileform/fhir/CodeSystem/MobileFormTenantsCs"
@@ -46,7 +46,7 @@ It answers the question: _“Which organization owns the configuration, endpoint
 
 * contained ^short = "Used for carrying banner image"
 
-* extension contains extBannerImage named bannerImageExtension 0..1 MS and OrganizationSettings named organizationSettings 1..1 MS
+* extension contains extBannerImage named bannerImageExtension 0..1 MS and OrganizationSettings named organizationSettings 0..1 MS
 
 
 // ---- Explicitly prohibited elements (not used in this profile) ----

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -10,6 +10,8 @@ Appointment representation of a booked visit.
 
 """
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PortalAppointment instance."
+* meta.versionId 0..1 MS
+* meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAppointment so clients can safely process it as the WOF Portal service concept profile."
 
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAppointment.fsh
@@ -56,6 +56,8 @@ Appointment representation of a booked visit.
 * participant[patient].actor only Reference(PortalPatient)
 * participant[patient].actor.reference 0..0 MS
 
+* status from BookedAppointmentStatuses (required)
+
 * comment 0..1 MS
 
 * extension contains WofBaseCharacteristic named characteristic 0..1

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -10,6 +10,8 @@ Appointment representation of an available appointment.
 * meta.profile = Canonical(PortalAvailableAppointment)
 
 * meta.versionId ^definition = "The technical resource version supplied by the server for change tracking of this specific PortalAvailableAppointment instance."
+* meta.versionId 0..1 MS
+* meta.versionId insert Obligation($wof-portal-server-actor, #SHALL:populate)
 * meta.profile ^definition = "Identifies that the resource conforms to PortalAvailableAppointment so clients can safely process it as the WOF Portal service concept profile."
 
 

--- a/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
+++ b/input/fsh/profiles/StrucutreDefintion-PortalAvailableAppointment.fsh
@@ -31,7 +31,7 @@ Appointment representation of an available appointment.
 * identifier[slot-id].value  1..1 MS
 * identifier[slot-id].type.text = "id for the available slot"
 
-* status = #proposed
+* status from AvailableAppointmentStatuses (required)
 * serviceType 1..*
 * serviceType.coding 1..*
 * serviceType.coding.system 1..1

--- a/input/fsh/valuesets/ValueSet-appointmentStatus.fsh
+++ b/input/fsh/valuesets/ValueSet-appointmentStatus.fsh
@@ -1,0 +1,20 @@
+ValueSet: AvailableAppointmentStatuses
+Id: available-appointment-statuses
+Title: "Find Appointment Statuses"
+Description: "Value set for allowed appointment statuses in WOF when an appointment isn't booked yet."
+
+* ^status = #active
+
+* include http://hl7.org/fhir/appointmentstatus#proposed "The appointment is listed as bookable"
+* include http://hl7.org/fhir/appointmentstatus#pending "The appointment is pending confirmation, used in the $book operation payload."
+
+
+ValueSet: BookedAppointmentStatuses
+Id: booked-appointment-statuses
+Title: "Booked Appointment Statuses"
+Description: "Value set for allowed appointment statuses in WOF when an appointment is booked."
+
+* ^status = #active
+
+* include http://hl7.org/fhir/appointmentstatus#booked "The appointment is confirmed to occur at the specified date/time. | A successful book response returns status #booked." 
+* include http://hl7.org/fhir/appointmentstatus#cancelled "Used in the $book operation payload to request cancellation of an appointment"

--- a/input/pagecontent/OperationDefinition-BookAppointment-intro.md
+++ b/input/pagecontent/OperationDefinition-BookAppointment-intro.md
@@ -1,0 +1,2 @@
+To be able to use this operation the customer must use a "patient-token", i.e the patient must be signed in.
+ To get a patient token the client must resolve the [OIDC process](./get-started.html#patient-authentication). 

--- a/input/pagecontent/get-started.md
+++ b/input/pagecontent/get-started.md
@@ -179,7 +179,7 @@ The system token represents the consumer integration and is intended for integra
 Patient authentication is performed using OpenID Connect through Service Well’s Keycloak servers. Depending on market and environment, Service Well provides access to the applicable national BankID solution, for example Norwegian BankID in Norway and Swedish BankID in Sweden.
 
 For the current sandbox setup, the consumer should use the following OIDC configuration.
-##### OIDC configuration
+##### OIDC configuration (Norwegian)
 
 Well-known/discovery:
 ```

--- a/input/pagecontent/get-started.md
+++ b/input/pagecontent/get-started.md
@@ -176,7 +176,9 @@ The system token represents the consumer integration and is intended for integra
 
 #### Patient authentication
 
-Patient authentication is performed using OpenID Connect through Service Well’s Keycloak servers. Depending on market and environment, Service Well provides access to the applicable national BankID solution, for example Norwegian BankID in Norway and Swedish BankID in Sweden.
+Patient authentication is performed using OpenID Connect. Depending on market and environment, Service Well provides access to the applicable e-identification solution.
+For example, but not limited to Norwegian BankID or Vipps in Norway and Swedish BankID in Sweden. Other providers can be activated.
+
 
 For the current sandbox setup, the consumer should use the following OIDC configuration.
 ##### OIDC configuration (Norwegian)
@@ -205,11 +207,11 @@ _Client ID and client secret is provided by Service well after contact. **To get
 The consumer should use the Authorization Code Flow with PKCE.
 `response_type=code`
 
-To route the user directly to Norwegian BankID, include the following Keycloak identity provider hint in the authorization request: `kc_idp_hint={providedCriiptoHint} `
+To route the user directly to Norwegian BankID, include the following identity provider hint in the authorization request: `kc_idp_hint={providedHint} `
 
 
 ##### Scopes
-The basic OIDC scope required for login is `openid`, and to recceive user/profile claims, the consumer should also request: `wof-profile`.
+The basic OIDC scope required for login is `openid`, and to receive user/profile claims, the consumer should also request: `wof-profile`.
 
 The client is configured with the following scopes as default:
 ```
@@ -219,7 +221,7 @@ PortalAccess
 Because PortalAccess is configured as a default scope, it does not need to be included explicitly in the authorization request.  
 In addition to the basic login scopes, the consumer should request the optional scopes required for the API resources and operations that the application needs access to. 
 
-The following scope can be requested:
+The following scopes can be requested:
 
 **Available scopes:**
  - patient/Patient.read
@@ -248,14 +250,18 @@ The consumer must also understand how patient context is established after authe
 Although the same client configuration may support both system authentication and patient authentication, these flows produce different tokens for different authorization contexts.
 
 ##### Example authorization request
-The following example starts an OIDC login using Authorization Code Flow with PKCE and routes the user directly to Norwegian BankID:
+The following example starts an OIDC Authorization Code Flow with PKCE and uses kc_idp_hint to route the user directly to the configured identity provider.
 ```
 GET https://portalauth-no.wellonfhir.se/realms/PortalNO-Dev/protocol/openid-connect/auth
-  ?client_id={{ clientid }}
-  &redirect_uri={{ registered_redirect_uri }}
+  ?client_id={{ client_id }}
+  &redirect_uri={{ url_encoded_registered_redirect_uri }}
   &response_type=code
   &scope=openid%20wof-profile%20patient%2FAppointment.read
-  &kc_idp_hint=CriiptoNO-orisdental
+  &kc_idp_hint={{ providerHint }}
+  &code_challenge={{ pkce_code_challenge }}
+  &code_challenge_method=S256
+  &state={{ random_state }}
+  [&nonce={{ random_nonce }}]
   ```
 
 ##### Patient-authorized calls

--- a/input/pagecontent/get-started.md
+++ b/input/pagecontent/get-started.md
@@ -3,7 +3,7 @@ This guide is written for **customers/partners** who want to integrate with the 
 ### Scope & user journey
 This section describes an **example booking journey** for a consumer-facing application using the Public API. The exact user interface, data-loading strategy, and order of steps are determined by the implementer.
 
-For example, some consumers may load clinics, treatments, and practitioners progressively as the patient makes selections, while others may preload this information using available API operations such as $get-offer-context. The API supports different implementation patterns.
+For example, some consumers may load clinics, treatments, and practitioners progressively as the patient makes selections, while others may preload this information using available API operations such as $get-offers-context. The API supports different implementation patterns.
 <div style="display:flex; gap:2rem; align-items:flex-start;">
   <div style="flex:1; min-width:0;">
     <p><strong>1. Select clinic and/or treatment</strong><br/>The booking journey typically starts with the patient selecting a clinic, a treatment, or both. Clinics and treatments can be used as filters for each other, and the order in which they are presented is up to the implementer.</p>
@@ -181,7 +181,7 @@ For example, but not limited to Norwegian BankID or Vipps in Norway and Swedish 
 
 
 For the current sandbox setup, the consumer should use the following OIDC configuration.
-##### OIDC configuration (Norwegian)
+##### OIDC configuration (Norway)
 
 Well-known/discovery:
 ```
@@ -202,7 +202,7 @@ Client secret:
 Provided separately through secure sharing
 ```
 
-_Client ID and client secret is provided by Service well after contact. **To get you client values contact support@servicewell.se**_
+_Client ID and client secret are provided by Service Well after contact. **To get your client values, contact support@servicewell.se**_
 
 The consumer should use the Authorization Code Flow with PKCE.
 `response_type=code`
@@ -235,7 +235,7 @@ The following scopes can be requested:
  - system/$find.read
  - system/$get-offers-context.read 
 
-**Requied scopes:**
+**Required scopes:**
  - openid
  - wof-profile
  - PortalAccess
@@ -310,11 +310,11 @@ The recommended usage is therefore:
   </tbody>
 </table>
 
-Simple (unordered)flow explanation:
+Simple (unordered) flow explanation:
 
-* Get booking context (`$getOffersContext`)  <br>Consumer  client loads the booking context needed to drive the bookingflow. The request can be altered to include services, where it can be booked, by which practitioner and the relationship between them.
+* Get booking context (`$getOffersContext`)  <br>Consumer client loads the booking context needed to drive the booking flow. The request can be altered to include services, where it can be booked, by which practitioner, and the relationship between them.
 
-* Find available times (`$find`)  <br>The consumer client request available appointments whithin the specified search criterias and time frame options in a given time range and receives proposed appointments. In the current API version, availability is retrieved per practitioner, so practitioner information must be available before calling $find. This is aligned with the IHE "Find Potential Appointments" interaction.
+* Find available times (`$find`)  <br>The consumer client requests available appointments within the specified search criteria and time frame options in a given time range and receives proposed appointments. In the current API version, availability is retrieved per practitioner, so practitioner information must be available before calling $find. This is aligned with the IHE "Find Potential Appointments" interaction.
 
 * Book an appointment (`$book` create)  <br>After the patient selects a proposed time (appointment), the consumer application submits a $book request to create the booking. In this implementation, the request must always contain the full Appointment resource representing the appointment to be booked.
 
@@ -322,7 +322,7 @@ Simple (unordered)flow explanation:
 
 * Cancel an appointment (`$book` cancel)  <br>If the patient cancels an appointment, the same $book operation is also used to cancel an existing appointment. To cancel a booking, the consumer application submits the full Appointment resource for the existing booking with the appropriate cancellation status set. On success, the API returns the cancelled appointment. In IHE Scheduling, cancellation is one of the defined trigger cases for $book, rather than a separate operation.
 
-* Error handling  <br>If something fails in `$find` or `$book` and a request cannot be fullfilled, the API returns an `OperationOutcome` with error details.
+* Error handling  <br>If something fails in `$find` or `$book` and a request cannot be fulfilled, the API returns an `OperationOutcome` with error details.
 
 **NOTE***
 For `$book`, a successful response returns a Bundle containing a single Appointment resource and may also include an OperationOutcome with supplemental information. An unsuccessful `$book` response returns only an OperationOutcome in the response Bundle.

--- a/input/pagecontent/get-started.md
+++ b/input/pagecontent/get-started.md
@@ -176,17 +176,50 @@ The system token represents the consumer integration and is intended for integra
 
 #### Patient authentication
 
-Patient authentication is based on OpenID Connect (OIDC).
+Patient authentication is performed using OpenID Connect through Service Well’s Keycloak servers. Depending on market and environment, Service Well provides access to the applicable national BankID solution, for example Norwegian BankID in Norway and Swedish BankID in Sweden.
 
-For endpoints that require patient authentication, the consumer must authenticate the patient through the configured OIDC flow and obtain a patient access token from the identity provider.
+For the current sandbox setup, the consumer should use the following OIDC configuration.
+##### OIDC configuration
 
-To support patient sign-in, the consumer must be configured with the required OIDC settings, including:
+Well-known/discovery:
+```
+https://portalauth-no.wellonfhir.se/realms/PortalNO-Dev/.well-known/openid-configuration
+```
+Authority/Issuer:
+```
+https://portalauth-no.wellonfhir.se/realms/PortalNO-Dev
+```
 
-- OIDC issuer URL
-- `client_id`
-- `client_secret`, where applicable for confidential clients
-- registered `redirect_uri` values, provided by the consumer and registered by Service Well
-- required scopes to request during authentication.
+<br>
+
+```
+Client ID:
+Customer oriented client-ID
+
+Client secret:
+Provided separately through secure sharing
+```
+
+_Client ID and client secret is provided by Service well after contact. **To get you client values contact support@servicewell.se**_
+
+The consumer should use the Authorization Code Flow with PKCE.
+`response_type=code`
+
+To route the user directly to Norwegian BankID, include the following Keycloak identity provider hint in the authorization request: `kc_idp_hint={providedCriiptoHint} `
+
+
+##### Scopes
+The basic OIDC scope required for login is `openid`, and to recceive user/profile claims, the consumer should also request: `wof-profile`.
+
+The client is configured with the following scopes as default:
+```
+openid
+PortalAccess
+```
+Because PortalAccess is configured as a default scope, it does not need to be included explicitly in the authorization request.  
+In addition to the basic login scopes, the consumer should request the optional scopes required for the API resources and operations that the application needs access to. 
+
+The following scope can be requested:
 
 **Available scopes:**
  - patient/Patient.read
@@ -213,6 +246,17 @@ The consumer must also understand how patient context is established after authe
 - through a dedicated endpoint, for example a `patient`-style endpoint
 
 Although the same client configuration may support both system authentication and patient authentication, these flows produce different tokens for different authorization contexts.
+
+##### Example authorization request
+The following example starts an OIDC login using Authorization Code Flow with PKCE and routes the user directly to Norwegian BankID:
+```
+GET https://portalauth-no.wellonfhir.se/realms/PortalNO-Dev/protocol/openid-connect/auth
+  ?client_id={{ clientid }}
+  &redirect_uri={{ registered_redirect_uri }}
+  &response_type=code
+  &scope=openid%20wof-profile%20patient%2FAppointment.read
+  &kc_idp_hint=CriiptoNO-orisdental
+  ```
 
 ##### Patient-authorized calls
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicewell.fhir.wof-portal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "IG",
   "canonical": "https://canonical.fhir.link/servicewell/wof-portal",
   "url": "https://canonical.fhir.link/servicewell/wof-portal/ImplementationGuide/servicewell.fhir.wof-portal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicewell.fhir.wof-portal",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "type": "IG",
   "canonical": "https://canonical.fhir.link/servicewell/wof-portal",
   "url": "https://canonical.fhir.link/servicewell/wof-portal/ImplementationGuide/servicewell.fhir.wof-portal",

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,17 +1,10 @@
 {
    "package-id" : "servicewell.fhir.wof-portal",
-   "version" : "1.0.0",
-   "path" : "https://canonical.fhir.link/servicewell/wof-portal/1.0.0",
-   "mode" : "milestone",
-   "status" : "release",
+   "version" : "1.0.1",
+   "path" : "https://canonical.fhir.link/servicewell/wof-portal/1.0.1",
+   "mode" : "technical-correction",
+   "status" : "update",
    "sequence" : "V1 Release",
-   "desc" : "Initial release of WOF Portal public API.",
-   "first" : true,
-   "title" : "Wof Portal Public API",
-   "ci-build" : "https://build.fhir.org/ig/servicewell/servicewell.fhir.wof-portal/branches/main",
-   "registry-description" : "This IG defines the ServiceWell WOF Portal public API in FHIR, including the core structures and terminology needed for consistent integrations. This is the initial release (v1.0.0) and represents the first public version of the specification",
-   "registry-country" : "SE",
-   "registry-authority" : "Service Well AB",
-   "category" : "Appointment Booking Service",
-   "introduction" : "This Implementation Guide describes Service Well’s WOF Portal for online appointment booking. It provides a shared foundation for presenting services and availability, so patients can book care more easily and providers can reduce manual administration. The intent is to improve access to care through a consistent, trustworthy booking experience."
+   "desc" : "Updated documentation for Portal public API.",
+   "first" : false
 }

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,7 +1,7 @@
 {
    "package-id" : "servicewell.fhir.wof-portal",
-   "version" : "1.0.1",
-   "path" : "https://canonical.fhir.link/servicewell/wof-portal/1.0.1",
+   "version" : "1.0.0",
+   "path" : "https://canonical.fhir.link/servicewell/wof-portal/1.0.0",
    "mode" : "technical-correction",
    "status" : "update",
    "sequence" : "V1 Release",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,11 +9,11 @@ name: Wof Portal ITB
 title: ITB - Online appointment booking service 
 description: Service Well's online appointment booking service - A Practical Blueprint for Upgrading Dental Care
 status: active # draft | active | retired | unknown
-version: 1.0.0
+version: 1.0.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 language: en-US
 copyrightYear: 2025+
-releaseLabel:  Initial Release
+releaseLabel:  Documentation update
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 # jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: Wof Portal ITB
 title: ITB - Online appointment booking service 
 description: Service Well's online appointment booking service - A Practical Blueprint for Upgrading Dental Care
 status: active # draft | active | retired | unknown
-version: 1.0.1
+version: 1.0.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 language: en-US
 copyrightYear: 2025+


### PR DESCRIPTION
This pull request provides a documentation update and several technical corrections to the WOF Portal FHIR Implementation Guide. The main focus is on improving patient authentication documentation and refining the datastructures, as well as their documentation to better reflect the current state of the API and how it's intended to be used.

**Key changes include:**

### Patient Authentication Documentation

* Expanded and clarified the patient authentication section in `get-started.md`, detailing the OIDC flow, configuration for sandbox environments, required scopes, and provided a sample authorization request, including BankID integration specifics. [[1]](diffhunk://#diff-a736e32cf009102a4fa2c7897339182b694965c1f89c56646b97c9b69b7dacc2L179-R222) [[2]](diffhunk://#diff-a736e32cf009102a4fa2c7897339182b694965c1f89c56646b97c9b69b7dacc2R250-R260)
* Added a note to the `OperationDefinition-BookAppointment-intro.md` clarifying that a patient must be signed in using a patient-token to use the appointment booking operation.

### Appointment Booking Operation and Examples

* Updated the `Operation-BookAppointments.fsh` to:
  - Rename input parameters for clarity (`appointment-resource` and `patient-resource` instead of `appointment` and `patient-identifier`).
  - Change the patient input from an identifier to a full Patient resource.
  - Comment out the use of an output profile and the alternative appointment-reference parameter due to lack of current support. [[1]](diffhunk://#diff-34f5bc0f01f3a066637dd2126a4e3d620efcceb4e4c85fac2fe7c68b9c5ac245L26-R30) [[2]](diffhunk://#diff-34f5bc0f01f3a066637dd2126a4e3d620efcceb4e4c85fac2fe7c68b9c5ac245L49-R64)
* Added a comprehensive example (`AppointmnetBook.fsh`) demonstrating how to invoke the Appointment/$book operation with all required parameters and resources.

### FHIR Resource Profile Improvements

* Added and enforced population of `meta.versionId` with appropriate obligations in multiple profiles (`PortalPatient`, `PractitionerRolePortal`, `ServiceProviderPortal`, `PortalAppointment`, `PortalAvailableAppointment`, `HealthcareServicePortal`). [[1]](diffhunk://#diff-873dbbb4c0980710c1a261c3040cebabf478ac0254fb1e16aa343b2b984827c8R12-R14) [[2]](diffhunk://#diff-8144cb991c65cd0be265533954c30f5d8399b1d481f79a2ac51a26eb9e318e29L25-R26) [[3]](diffhunk://#diff-16e3df3b414242f8cb4f23f0d0d72c6b3e136f4558efef1bf4a53087a88a13b2R23-R51) [[4]](diffhunk://#diff-99462998801db28ddb937a360bc0fc41df9a844cf1b5a72b1dd27cc11eb82a60R13-R14) [[5]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162R13-R14) [[6]](diffhunk://#diff-883d0c0e3fd9d69d54d30cbe400b8c5bc5058e861c20ea889750e971a43413cbR23-R24)
* Strengthened the `PortalPatient` profile to require a mobile phone, at least one name, and specific constraints on name and telecom elements.
* Enhanced the `ServiceProviderPortal` profile to support new identifier slices for `MobileFormTenant` and `NameAsCode`, and added support for an organization banner image extension.
* Introduced a new extension `extBannerImage` for associating a banner image with an Organization via a Binary reference.

### Minor Corrections

* Corrected an example instance to use the `ServiceProviderPortal` profile instead of `Organization`.

### Versioning

* Updated the IG version to `1.0.1` and revised release labels and publication metadata to reflect a documentation update and technical correction. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-5a1dd5a743b074aee2ee813472f237a649d5c42fb46c9e6fd0bbc66a519755b7L3-R9) [[3]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L12-R16)


---

**References:**  
[[1]](diffhunk://#diff-a736e32cf009102a4fa2c7897339182b694965c1f89c56646b97c9b69b7dacc2L179-R222) [[2]](diffhunk://#diff-a736e32cf009102a4fa2c7897339182b694965c1f89c56646b97c9b69b7dacc2R250-R260) [[3]](diffhunk://#diff-c26b71eb15cc810a6b867e3929ab0525aa471e9f163f3a2062a5871251d4c882R1-R2) [[4]](diffhunk://#diff-34f5bc0f01f3a066637dd2126a4e3d620efcceb4e4c85fac2fe7c68b9c5ac245L26-R30) [[5]](diffhunk://#diff-34f5bc0f01f3a066637dd2126a4e3d620efcceb4e4c85fac2fe7c68b9c5ac245L49-R64) [[6]](diffhunk://#diff-02034c7d3316e8a4e5489f6975c622d5d5d4fd7aa4d8c4671bd2facdc11e5df1R1-R59) [[7]](diffhunk://#diff-873dbbb4c0980710c1a261c3040cebabf478ac0254fb1e16aa343b2b984827c8R12-R14) [[8]](diffhunk://#diff-8144cb991c65cd0be265533954c30f5d8399b1d481f79a2ac51a26eb9e318e29L25-R26) [[9]](diffhunk://#diff-16e3df3b414242f8cb4f23f0d0d72c6b3e136f4558efef1bf4a53087a88a13b2R23-R51) [[10]](diffhunk://#diff-99462998801db28ddb937a360bc0fc41df9a844cf1b5a72b1dd27cc11eb82a60R13-R14) [[11]](diffhunk://#diff-d6ea016d7c250dc39451c804ffddcb60267afaa8c5f099429031173b19d42162R13-R14) [[12]](diffhunk://#diff-883d0c0e3fd9d69d54d30cbe400b8c5bc5058e861c20ea889750e971a43413cbR23-R24) [[13]](diffhunk://#diff-873dbbb4c0980710c1a261c3040cebabf478ac0254fb1e16aa343b2b984827c8L27-R42) [[14]](diffhunk://#diff-c640545d6838e52973ef4095e1b3c974f645141099b3eedc5e7bdd185924f7dfR1-R8) [[15]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[16]](diffhunk://#diff-5a1dd5a743b074aee2ee813472f237a649d5c42fb46c9e6fd0bbc66a519755b7L3-R9) [[17]](diffhunk://#diff-9bd0b4a19606858a6c686eb415df9224a0610668a04e98aafbc7985cacb4b0e4L12-R16) [[18]](diffhunk://#diff-5beb16cfe9ce82c9d7667fc90efeb5fbf521a0b0c25e10b914cdf17cdd956593L13-R13)